### PR TITLE
fix: pin Go 1.24, fix lint errors, apply gofumpt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       GOPRIVATE: "github.com/msutara/*"
       GONOSUMCHECK: "github.com/msutara/*"
+      GOTOOLCHAIN: "local"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -36,6 +37,7 @@ jobs:
     env:
       GOPRIVATE: "github.com/msutara/*"
       GONOSUMCHECK: "github.com/msutara/*"
+      GOTOOLCHAIN: "local"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/apiclient.go
+++ b/apiclient.go
@@ -43,7 +43,7 @@ func (c *apiClient) get(ctx context.Context, path string, dst any) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024)) //nolint:errcheck // best-effort error detail
 		return fmt.Errorf("api %s returned %d: %s", path, resp.StatusCode, body)
 	}
 
@@ -52,6 +52,7 @@ func (c *apiClient) get(ctx context.Context, path string, dst any) error {
 			return fmt.Errorf("decode response: %w", err)
 		}
 	}
+
 	return nil
 }
 
@@ -61,6 +62,7 @@ func (c *apiClient) post(ctx context.Context, path string, dst any) error {
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}
+
 	if c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
@@ -73,7 +75,7 @@ func (c *apiClient) post(ctx context.Context, path string, dst any) error {
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted &&
 		resp.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024)) //nolint:errcheck // best-effort error detail
 		return fmt.Errorf("api %s returned %d: %s", path, resp.StatusCode, body)
 	}
 
@@ -82,6 +84,7 @@ func (c *apiClient) post(ctx context.Context, path string, dst any) error {
 			return fmt.Errorf("decode response: %w", err)
 		}
 	}
+
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/msutara/config-manager-web
 
-go 1.25.0
+go 1.24.0
 
-require github.com/go-chi/chi/v5 v5.2.1 // indirect
+require github.com/go-chi/chi/v5 v5.2.1

--- a/routes.go
+++ b/routes.go
@@ -84,13 +84,15 @@ func (h *Handler) handleUpdateRun(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		// html.EscapeString on error message for defense in depth.
 		safeErr := html.EscapeString(err.Error())
-		w.Write([]byte(`<div class="alert alert-error">Failed to start ` +
+		//nolint:errcheck // HTTP response write — no recovery possible
+		_, _ = w.Write([]byte(`<div class="alert alert-error">Failed to start ` +
 			updateType + ` update: ` + safeErr + `</div>`))
 		return
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(`<div class="alert alert-success">` +
+	//nolint:errcheck // HTTP response write — no recovery possible
+	_, _ = w.Write([]byte(`<div class="alert alert-success">` +
 		updateType + ` update started successfully</div>`))
 }
 

--- a/web.go
+++ b/web.go
@@ -42,25 +42,34 @@ func NewHandler(apiURL, authToken string) http.Handler {
 		},
 	}
 
+	mustRead := func(name string) []byte {
+		b, err := fs.ReadFile(templateFS, "templates/"+name)
+		if err != nil {
+			panic("read " + name + ": " + err.Error())
+		}
+		return b
+	}
+
 	// Parse each page template with its own copy of the layout to avoid
 	// "content" block name collisions between pages.
-	layoutBytes, _ := fs.ReadFile(templateFS, "templates/layout.html")
+	layoutBytes := mustRead("layout.html")
 	h.templates = make(map[string]*template.Template)
 	for _, page := range []string{"dashboard.html", "update.html", "network.html"} {
 		t := template.Must(template.New("").Funcs(funcMap).Parse(string(layoutBytes)))
-		pageBytes, _ := fs.ReadFile(templateFS, "templates/"+page)
-		template.Must(t.Parse(string(pageBytes)))
+		template.Must(t.Parse(string(mustRead(page))))
 		h.templates[page] = t
 	}
 	// Login is standalone (no layout).
-	loginBytes, _ := fs.ReadFile(templateFS, "templates/login.html")
 	h.templates["login.html"] = template.Must(
-		template.New("").Funcs(funcMap).Parse(string(loginBytes)))
+		template.New("").Funcs(funcMap).Parse(string(mustRead("login.html"))))
 
 	h.router = chi.NewRouter()
 
 	// Static assets — no auth required.
-	staticSub, _ := fs.Sub(staticFS, "static")
+	staticSub, err := fs.Sub(staticFS, "static")
+	if err != nil {
+		panic("fs.Sub static: " + err.Error())
+	}
 	h.router.Handle("/static/*", http.StripPrefix("/static/",
 		http.FileServer(http.FS(staticSub))))
 
@@ -117,5 +126,5 @@ func (h *Handler) render(w http.ResponseWriter, name string, data any) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write(buf.Bytes())
+	_, _ = w.Write(buf.Bytes()) //nolint:errcheck // HTTP response write
 }


### PR DESCRIPTION
## Changes

- **go.mod**: Pin to Go 1.24.0 (was 1.25.0 from local toolchain). golangci-lint v1.64.8 is built with Go 1.24 and refuses to analyze Go 1.25 targets.
- **CI workflow**: Set \GOTOOLCHAIN=local\ on lint and test jobs to prevent runner auto-upgrade.
- **web.go**: Extract \mustRead\ helper for embedded template reads (removes duplication, consistent panic messages). Add \//nolint:errcheck\ on HTTP response write.
- **routes.go**: Move \//nolint:errcheck\ directives above statements for readability.
- **apiclient.go**: Add \//nolint:errcheck\ on best-effort \io.ReadAll\ calls + gofumpt formatting.
- **go.mod**: Mark chi/v5 as direct dependency.
- All Go files formatted with gofumpt.