### PR TITLE
fix: set HX-Refresh header after successful settings save

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -412,6 +412,7 @@ func (h *Handler) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			strings.Join(updatedKeys, ", "), strings.Join(failedKeys, ", ")) //nolint:errcheck // strings.Builder
 		b.WriteString(`</div>`) //nolint:errcheck // strings.Builder
 	} else {
+		w.Header().Set("HX-Refresh", "true")
 		b.WriteString(`<div class="alert alert-success">Settings updated successfully</div>`) //nolint:errcheck // strings.Builder
 	}
 	for _, warn := range warnings {

--- a/routes_test.go
+++ b/routes_test.go
@@ -1187,6 +1187,9 @@ func TestUpdateSettings_HappyPath(t *testing.T) {
 	if !strings.Contains(w.Body.String(), "Settings updated successfully") {
 		t.Errorf("expected success message, got %q", w.Body.String())
 	}
+	if w.Header().Get("HX-Refresh") != "true" {
+		t.Error("should set HX-Refresh header on successful settings save")
+	}
 }
 
 func TestUpdateSettings_SingleField(t *testing.T) {
@@ -1206,6 +1209,9 @@ func TestUpdateSettings_SingleField(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "Settings updated successfully") {
 		t.Errorf("expected success, got %q", w.Body.String())
+	}
+	if w.Header().Get("HX-Refresh") != "true" {
+		t.Error("should set HX-Refresh header on successful settings save")
 	}
 }
 
@@ -1833,6 +1839,9 @@ func TestUpdateSettings_PartialFailure(t *testing.T) {
 	}
 	if !strings.Contains(respBody, "failed to update") {
 		t.Errorf("should mention failed keys, got %q", respBody)
+	}
+	if got := w.Header().Get("HX-Refresh"); got != "" {
+		t.Errorf("partial failure must not set HX-Refresh, got %q", got)
 	}
 }
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -96,6 +96,8 @@ Settings (editable form with htmx):
 
 Each setting change calls `PUT /api/v1/plugins/update/settings` with `{key, value}`.
 The form submits via htmx and displays success/error/warning messages inline.
+On success the handler sets `HX-Refresh: true` so the browser reloads the page
+with fresh config values from the API.
 All three fields use hidden `*_original` inputs (`schedule_original`,
 `auto_security_original`, `security_source_original`) to detect changes;
 unchanged fields are not re-submitted, avoiding redundant API calls.


### PR DESCRIPTION
After saving settings via htmx form, the page did not refresh to display updated config values.

## Problem
The handleUpdateSettings handler returns an htmx HTML fragment with a success message but does not trigger a page reload, so the main update page still shows stale config values.

## Fix
Set HX-Refresh: true header on the success path so the browser reloads with fresh data from the API.

## Changes
- routes.go: Add HX-Refresh header on success
- routes_test.go: HX-Refresh assertions in HappyPath, SingleField, and negative assertion in PartialFailure
- specs/SPEC.md: Document HX-Refresh behavior

## Testing
All 76+ tests pass. Fleet-reviewed by 5 agents.
