### PR TITLE
refactor: rename security_source 'available' to 'detected'

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -37,7 +37,7 @@ Below the actions, the **Edit Settings** form allows changing:
 
 - **Cron Schedule** — when automated updates run (e.g. `0 3 * * *` for 3 AM daily)
 - **Auto Security Updates** — enable or disable automatic security updates
-- **Security Source** — whether to use `available` (OS-provided) or `always` check
+- **Security Source** — whether to use `detected` (OS-provided) or `always` check
 
 Changes are saved immediately via the core API and take effect on next schedule tick.
 Only fields that differ from their original values are sent, preventing redundant API

--- a/routes.go
+++ b/routes.go
@@ -367,7 +367,7 @@ func (h *Handler) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			changes = append(changes, settingChange{key: "auto_security", value: v == "true"})
 		}
 	}
-	if v := r.FormValue("security_source"); v == "available" || v == "always" {
+	if v := r.FormValue("security_source"); v == "detected" || v == "always" {
 		if orig := r.FormValue("security_source_original"); orig == "" || orig != v {
 			changes = append(changes, settingChange{key: "security_source", value: v})
 		}

--- a/routes_test.go
+++ b/routes_test.go
@@ -85,7 +85,7 @@ func mockAPI(t *testing.T) *httptest.Server {
 		json.NewEncoder(w).Encode(UpdateConfig{
 			SecurityAvailable: boolPtr(true),
 			AutoSecurity:      boolPtr(true),
-			SecuritySource:    "available",
+			SecuritySource:    "detected",
 			Schedule:          "0 3 * * *",
 		})
 	})
@@ -1174,7 +1174,7 @@ func TestUpdateSettings_HappyPath(t *testing.T) {
 	defer api.Close()
 
 	h := newTestHandler(t, api.URL, "")
-	body := strings.NewReader("schedule=0+4+*+*+*&schedule_original=0+3+*+*+*&auto_security=true&auto_security_original=false&security_source=always&security_source_original=available")
+	body := strings.NewReader("schedule=0+4+*+*+*&schedule_original=0+3+*+*+*&auto_security=true&auto_security_original=false&security_source=always&security_source_original=detected")
 	req := httptest.NewRequest(http.MethodPost, "/update/settings", body)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -1822,7 +1822,7 @@ func TestUpdateSettings_PartialFailure(t *testing.T) {
 	defer api.Close()
 
 	h := newTestHandler(t, api.URL, "")
-	body := strings.NewReader("schedule=0+3+*+*+*&schedule_original=0+5+*+*+*&auto_security=true&auto_security_original=false&security_source=always&security_source_original=available")
+	body := strings.NewReader("schedule=0+3+*+*+*&schedule_original=0+5+*+*+*&auto_security=true&auto_security_original=false&security_source=always&security_source_original=detected")
 	req := httptest.NewRequest(http.MethodPost, "/update/settings", body)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -92,7 +92,7 @@ Settings (editable form with htmx):
 
 - **Schedule** — cron expression (text input)
 - **Auto Security Updates** — enabled/disabled (select)
-- **Security Source** — available/always (select)
+- **Security Source** — detected/always (select)
 
 Each setting change calls `PUT /api/v1/plugins/update/settings` with `{key, value}`.
 The form submits via htmx and displays success/error/warning messages inline.
@@ -104,7 +104,7 @@ unchanged fields are not re-submitted, avoiding redundant API calls.
 Clearing the schedule (empty value when original was non-empty) sends an
 explicit empty value to the API.
 Input validation rejects invalid enum values (auto_security must be `true`/`false`,
-security_source must be `available`/`always`).
+security_source must be `detected`/`always`).
 All API-provided data (errors, warnings) is escaped with `html.EscapeString` before
 rendering to prevent XSS.
 

--- a/templates/update.html
+++ b/templates/update.html
@@ -111,7 +111,7 @@
             <input type="hidden" name="security_source_original" value="{{ .Config.SecuritySource }}">
             <select id="security_source" name="security_source" class="form-input">
                 {{ if not .Config.SecuritySource }}<option value="" selected>— unchanged —</option>{{ end }}
-                <option value="available"{{ if eq .Config.SecuritySource "available" }} selected{{ end }}>Available</option>
+                <option value="detected"{{ if eq .Config.SecuritySource "detected" }} selected{{ end }}>Detected</option>
                 <option value="always"{{ if eq .Config.SecuritySource "always" }} selected{{ end }}>Always</option>
             </select>
         </div>


### PR DESCRIPTION
Update all references to the \security_source\ config value to match the upstream rename in cm-plugin-update (#18).

Changes in routes.go, routes_test.go, templates/update.html, specs/SPEC.md, docs/USAGE.md.