### PR TITLE
fix: hide security fields in web UI when unavailable (fail-closed)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/routes_test.go
+++ b/routes_test.go
@@ -985,6 +985,83 @@ func TestUpdatePage_SecurityHiddenWhenUnavailable(t *testing.T) {
 	if strings.Contains(w.Body.String(), "Run Security Update") {
 		t.Fatal("security update button should be hidden when unavailable")
 	}
+	if strings.Contains(w.Body.String(), "Auto Security Updates") {
+		t.Fatal("auto_security form field should be hidden when unavailable")
+	}
+	if strings.Contains(w.Body.String(), "Security Source") {
+		t.Fatal("security_source form field should be hidden when unavailable")
+	}
+}
+
+func TestUpdatePage_SecurityShownWhenAvailable(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/plugins/update/status":
+			json.NewEncoder(w).Encode([]PendingUpdate{
+				{Package: "vim", CurrentVersion: "9.0.1", NewVersion: "9.0.2"},
+			})
+		case "/api/v1/plugins/update/logs":
+			json.NewEncoder(w).Encode(RunStatus{})
+		case "/api/v1/plugins/update/config":
+			json.NewEncoder(w).Encode(UpdateConfig{SecurityAvailable: boolPtr(true)})
+		}
+	}))
+	defer api.Close()
+
+	h := newTestHandler(t, api.URL, "")
+	req := httptest.NewRequest(http.MethodGet, "/update", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Run Security Update") {
+		t.Fatal("security update button should be visible when available")
+	}
+	if !strings.Contains(body, "Auto Security Updates") {
+		t.Fatal("auto_security form field should be visible when available")
+	}
+	if !strings.Contains(body, "Security Source") {
+		t.Fatal("security_source form field should be visible when available")
+	}
+}
+
+func TestUpdatePage_SecurityHiddenWhenNil(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/plugins/update/status":
+			json.NewEncoder(w).Encode([]PendingUpdate{
+				{Package: "vim", CurrentVersion: "9.0.1", NewVersion: "9.0.2"},
+			})
+		case "/api/v1/plugins/update/logs":
+			json.NewEncoder(w).Encode(RunStatus{})
+		case "/api/v1/plugins/update/config":
+			// SecurityAvailable omitted → nil (fail-closed).
+			json.NewEncoder(w).Encode(UpdateConfig{})
+		}
+	}))
+	defer api.Close()
+
+	h := newTestHandler(t, api.URL, "")
+	req := httptest.NewRequest(http.MethodGet, "/update", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "Run Security Update") {
+		t.Fatal("security update button should be hidden when SecurityAvailable is nil")
+	}
+	if strings.Contains(body, "Auto Security Updates") {
+		t.Fatal("auto_security form field should be hidden when SecurityAvailable is nil")
+	}
+	if strings.Contains(body, "Security Source") {
+		t.Fatal("security_source form field should be hidden when SecurityAvailable is nil")
+	}
 }
 
 func TestUpdatePage_PartialAPIFailure(t *testing.T) {

--- a/templates/update.html
+++ b/templates/update.html
@@ -64,6 +64,7 @@
 <h3>Configuration</h3>
 <div class="card">
     <table class="info-table">
+        {{ if and (not .ConfigErr) .Config.SecurityAvailable (derefBool .Config.SecurityAvailable) }}
         <tr>
             <td>Security Source</td>
             <td>{{ if .Config.SecuritySource }}{{ .Config.SecuritySource }}{{ else }}N/A{{ end }}</td>
@@ -72,6 +73,7 @@
             <td>Auto Security Updates</td>
             <td>{{ if .Config.AutoSecurity }}{{ if derefBool .Config.AutoSecurity }}Enabled{{ else }}Disabled{{ end }}{{ else }}Unknown{{ end }}</td>
         </tr>
+        {{ end }}
         {{ if .Config.Schedule }}
         <tr>
             <td>Schedule</td>
@@ -97,6 +99,7 @@
                    placeholder="e.g. 0 3 * * *"
                    class="form-input">
         </div>
+        {{ if and (not .ConfigErr) .Config.SecurityAvailable (derefBool .Config.SecurityAvailable) }}
         <div class="form-group">
             <label for="auto_security">Auto Security Updates</label>
             <input type="hidden" name="auto_security_original" value="{{ if .Config.AutoSecurity }}{{ if derefBool .Config.AutoSecurity }}true{{ else }}false{{ end }}{{ end }}">
@@ -115,6 +118,7 @@
                 <option value="always"{{ if eq .Config.SecuritySource "always" }} selected{{ end }}>Always</option>
             </select>
         </div>
+        {{ end }}
         <div class="actions">
             <button type="submit" class="btn btn-primary">Save Settings</button>
             <span id="settings-spinner" class="spinner"></span>


### PR DESCRIPTION
## Changes
- Display table rows (Security Source, Auto Security Updates) hidden when `SecurityAvailable` is false/nil
- Form fields (auto_security dropdown, security_source dropdown) hidden likewise
- Guard includes `(not .ConfigErr)` for consistency with fail-closed semantics
- Added `.gitattributes` (`* text=auto eol=lf`) to prevent phantom CRLF diffs

## Tests added
- `TestUpdatePage_SecurityShownWhenAvailable` (positive case)
- `TestUpdatePage_SecurityHiddenWhenNil` (nil = fail-closed)