### PR TITLE
feat: TUI-web parity — package list, log viewer, confirmations, sidebar info

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ headless Debian-based nodes (Raspbian Bookworm ARM, Debian Bullseye slim).
 ## Features
 
 - Dashboard with hostname, OS, architecture, and live uptime
-- Update manager — pending counts, run full or security-only updates
+- Update manager — pending counts, package list, log viewer, run full or
+  security-only updates with confirmation dialogs
 - Network info — interfaces, connectivity status, DNS configuration
 - Cookie-based authentication using the same Bearer token as the API
 - Responsive dark theme — works on phones, tablets, and desktops
 - Server-rendered with htmx — no JavaScript build step required
 - Dynamic plugin sidebar — auto-discovers plugins from the core API registry
+- Sidebar system info — hostname, uptime, and API connection indicator
 
 ## Architecture
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -27,9 +27,14 @@ View pending updates, trigger operations, and edit settings:
 
 - **Pending Updates** — number of packages with available updates
 - **Security Updates** — security-specific updates (when security source available)
-- **Run Full Update** — triggers `apt-get upgrade` for all packages
-- **Run Security Update** — triggers security-only update (hidden on systems
-  without a separate security repository, such as Raspberry Pi OS)
+- **Package List** — table of individual pending packages showing name, current
+  version, new version, and a security badge for security-related updates
+- **Last Run** — type, status, timestamp, duration, and package count
+- **Log Viewer** — collapsible section showing raw log output from the last run
+- **Run Full Update** — triggers `apt-get upgrade` for all packages (confirmation
+  dialog prevents accidental clicks)
+- **Run Security Update** — triggers security-only update with confirmation
+  (hidden on systems without a separate security repository)
 
 ##### Edit Settings
 
@@ -59,11 +64,25 @@ Any plugin registered with CM Core whose name matches `[a-z][a-z0-9-]*`
 is automatically accessible via `/{plugin-name}` in the web UI, with actions
 rendered dynamically from plugin metadata, **unless** that path conflicts with
 an existing built-in route. Built-in routes (such as `/login`, `/update`,
-`/network`) always take precedence. Plugin actions that require POSTs are
+`/network`) always take precedence. Plugin POST actions show a confirmation
+dialog before executing. Plugin actions that require POSTs are
 exposed under `/{plugin-name}/actions/<action-path>` and invoked by the UI.
 The Update and Network pages above are hardcoded examples; additional plugins
 that follow the naming rule and do not conflict with built-in routes appear
 without code changes.
+
+## Sidebar
+
+The sidebar is present on every page and shows:
+
+- **Navigation links** — Dashboard, Update, Network, plus any registered plugins
+- **Connection indicator** — green dot when the core API is reachable
+- **Hostname** — device name fetched from the core API
+- **Uptime** — human-readable uptime (e.g. "up 2d 5h 30m")
+- **Logout** — button to end the authenticated session
+
+When the core API is unreachable, the sidebar degrades gracefully: navigation
+links use a stale cache and the host/uptime section is hidden.
 
 ## Browser Support
 

--- a/routes.go
+++ b/routes.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -284,6 +285,11 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		"Node":    node,
 		"NodeErr": nodeErr,
 	}
+	// Reuse dashboard NodeInfo for sidebar to avoid a second /api/v1/node call.
+	if nodeErr == nil {
+		data["SidebarNode"] = node
+		data["SidebarConnected"] = true
+	}
 	h.render(w, "dashboard.html", h.withPlugins(r, data))
 }
 
@@ -325,6 +331,17 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	if configErr != nil {
 		slog.Error("web: failed to fetch update config", "error", configErr)
+	}
+
+	// Cap log size to prevent excessive memory use on ARM devices.
+	// Truncate on a UTF-8 rune boundary to avoid splitting multi-byte characters.
+	const maxLogBytes = 256 << 10 // 256 KB
+	if len(runStatus.Log) > maxLogBytes {
+		cut := maxLogBytes
+		for cut > 0 && !utf8.RuneStart(runStatus.Log[cut]) {
+			cut--
+		}
+		runStatus.Log = runStatus.Log[:cut] + "\n…(truncated)"
 	}
 
 	// Compute counts from the pending list.

--- a/routes_test.go
+++ b/routes_test.go
@@ -78,7 +78,9 @@ func mockAPI(t *testing.T) *httptest.Server {
 			Type:      "full",
 			Status:    "completed",
 			StartedAt: "2026-02-27T10:00:00Z",
+			Duration:  "2m 15s",
 			Packages:  3,
+			Log:       "Updating openssl 3.0.1 -> 3.0.2\nUpdating curl 7.88.0 -> 7.88.1\nDone.",
 		})
 	})
 
@@ -636,6 +638,9 @@ func TestGenericPlugin_RendersForKnownPlugin(t *testing.T) {
 	if !strings.Contains(body, "/firewall/actions/reload") {
 		t.Error("action button should use proxied web path")
 	}
+	if !strings.Contains(body, `hx-confirm="Execute`) {
+		t.Error("generic POST actions should have hx-confirm for safety")
+	}
 	if !strings.Contains(body, "allow 22/tcp") {
 		t.Error("generic page should render fetched endpoint data")
 	}
@@ -983,7 +988,20 @@ func TestUpdatePage_WithMockAPI(t *testing.T) {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 	body := w.Body.String()
-	for _, want := range []string{"5", "2", "Security Update", "full", "completed"} {
+	for _, want := range []string{
+		"5", "2", "Security Update", "full", "completed",
+		// Package list table (parity with TUI).
+		"openssl", "3.0.1", "3.0.2",
+		"curl", "7.88.0", "7.88.1",
+		// Last run details.
+		"Duration: 2m 15s", "Packages: 3",
+		// Log viewer — presence and content.
+		"View log output",
+		"Updating openssl",
+		// Both confirmation dialogs.
+		"Run a full system update?",
+		"Run security-only update?",
+	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("update page should contain %q", want)
 		}
@@ -1001,6 +1019,12 @@ func TestUpdatePage_SecurityHiddenWhenUnavailable(t *testing.T) {
 			json.NewEncoder(w).Encode(RunStatus{})
 		case "/api/v1/plugins/update/config":
 			json.NewEncoder(w).Encode(UpdateConfig{SecurityAvailable: boolPtr(false)})
+		case "/api/v1/plugins":
+			json.NewEncoder(w).Encode([]map[string]any{})
+		case "/api/v1/node":
+			json.NewEncoder(w).Encode(NodeInfo{Hostname: "test"})
+		default:
+			http.NotFound(w, r)
 		}
 	}))
 	defer api.Close()
@@ -1021,6 +1045,48 @@ func TestUpdatePage_SecurityHiddenWhenUnavailable(t *testing.T) {
 	}
 	if strings.Contains(w.Body.String(), "Security Source") {
 		t.Fatal("security_source form field should be hidden when unavailable")
+	}
+	// Empty-state: log viewer should be absent when RunStatus has no log.
+	if strings.Contains(w.Body.String(), "View log output") {
+		t.Fatal("log viewer should be absent when RunStatus.Log is empty")
+	}
+}
+
+func TestUpdatePage_EmptyPendingHidesTable(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/plugins/update/status":
+			json.NewEncoder(w).Encode([]PendingUpdate{})
+		case "/api/v1/plugins/update/logs":
+			json.NewEncoder(w).Encode(RunStatus{Type: "full", Status: "completed"})
+		case "/api/v1/plugins/update/config":
+			json.NewEncoder(w).Encode(UpdateConfig{SecurityAvailable: boolPtr(true)})
+		case "/api/v1/plugins":
+			json.NewEncoder(w).Encode([]map[string]any{})
+		case "/api/v1/node":
+			json.NewEncoder(w).Encode(NodeInfo{Hostname: "test"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	h := newTestHandler(t, api.URL, "")
+	req := httptest.NewRequest(http.MethodGet, "/update", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	// Package table header should be absent when no pending updates.
+	if strings.Contains(body, "<th>Package</th>") {
+		t.Error("package table should not render when pending list is empty")
+	}
+	// Log viewer should be absent when RunStatus.Log is empty.
+	if strings.Contains(body, "View log output") {
+		t.Error("log viewer should not render when log is empty")
 	}
 }
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -76,17 +76,20 @@ Data source: `GET /api/v1/node`
 
 Displays:
 
-- Current status (running/idle)
-- Pending update count
-- Security update count
-- Last run time and result
+- Pending update count and security update count (summary cards)
+- **Package list** — table of individual pending packages with name, current
+  version, new version, and a security badge
+- **Last run** — type, status, timestamp, duration, and package count
+- **Log viewer** — collapsible `<details>` section showing raw log output
 - Configuration (security source availability, auto-update setting, schedule)
 
 Actions:
 
-- **Run Full Update** — `POST /api/v1/plugins/update/run`
-- **Run Security Update** — `POST /api/v1/plugins/update/run?type=security`
-  (only shown when security source is available)
+- **Run Full Update** — `POST /api/v1/plugins/update/run` with `{"type":"full"}`
+  JSON body, confirmation dialog
+- **Run Security Update** — `POST /api/v1/plugins/update/run` with
+  `{"type":"security"}` JSON body, confirmation dialog (only shown when
+  security source is available)
 
 Settings (editable form with htmx):
 
@@ -137,11 +140,28 @@ Data sources:
 - Uptime refresh: `hx-get="/" hx-trigger="every 30s" hx-select=".uptime-value"`
 - Update trigger: `hx-post="/update/run" hx-target="#update-result"`
 - Loading indicator: `hx-indicator="#update-spinner"`
+- Confirmation dialogs: `hx-confirm="..."` on destructive action buttons
 
 ### Response Fragments
 
 POST handlers return HTML fragments (not full pages) for htmx to swap
 into the target element. This avoids full page reloads.
+
+## Sidebar
+
+The sidebar appears on every page and contains:
+
+- **Navigation** — links to Dashboard, Update, Network, plus dynamically
+  discovered plugins from the core API
+- **Connection indicator** — green dot when core API is reachable, hidden
+  when unreachable
+- **Hostname and uptime** — fetched from `/api/v1/node` via `withPlugins()`
+  helper, gracefully hidden when API is down
+- **Logout button** — ends the authenticated session
+
+The sidebar uses a plugin cache with 30-second TTL and falls back to stale
+data when the API is unreachable (thundering-herd protected with double-check
+locking).
 
 ## Styling
 

--- a/static/style.css
+++ b/static/style.css
@@ -88,6 +88,27 @@ body {
     border-top: 1px solid var(--border);
 }
 
+.sidebar-info {
+    margin-bottom: 0.75rem;
+    font-size: 0.8rem;
+    line-height: 1.6;
+}
+
+.conn-dot { font-size: 0.7rem; margin-right: 0.25rem; }
+.conn-ok { color: var(--success); }
+.conn-off { color: var(--text-muted); }
+
+.sidebar-host {
+    color: var(--text);
+    font-weight: 600;
+}
+
+.sidebar-uptime {
+    display: block;
+    color: var(--text-muted);
+    padding-left: 1.1rem;
+}
+
 /* Main Content */
 
 .content {
@@ -192,6 +213,38 @@ h3 {
 .badge-routable, .badge-up { background: rgba(158, 206, 106, 0.2); color: var(--success); }
 .badge-carrier { background: rgba(224, 175, 104, 0.2); color: var(--warning); }
 .badge-off, .badge-down { background: rgba(247, 118, 142, 0.2); color: var(--error); }
+.badge-security { background: rgba(247, 118, 142, 0.2); color: var(--error); }
+
+/* Log viewer */
+
+.log-viewer {
+    margin: 1rem 0;
+}
+
+.log-viewer summary {
+    cursor: pointer;
+    color: var(--accent);
+    font-size: 0.9rem;
+    padding: 0.5rem 0;
+}
+
+.log-viewer summary:hover {
+    color: var(--accent-hover);
+}
+
+.log-pre {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 1rem;
+    font-size: 0.8rem;
+    overflow-x: auto;
+    max-height: 400px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+    margin-top: 0.5rem;
+}
 
 /* Buttons */
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -26,6 +26,13 @@
             {{ end }}
         </ul>
         <div class="sidebar-footer">
+            {{ if .SidebarNode }}
+            <div class="sidebar-info" role="status" aria-label="{{ if .SidebarConnected }}Connected{{ else }}Disconnected{{ end }}: {{ .SidebarNode.Hostname }}">
+                <span class="conn-dot {{ if .SidebarConnected }}conn-ok{{ else }}conn-off{{ end }}" aria-hidden="true">●</span>
+                <span class="sidebar-host">{{ .SidebarNode.Hostname }}</span>
+                <span class="sidebar-uptime">{{ if gt .SidebarNode.UptimeSeconds 0 }}up {{ end }}{{ formatUptime .SidebarNode.UptimeSeconds }}</span>
+            </div>
+            {{ end }}
             <form method="post" action="/auth/logout">
                 <button type="submit" class="btn btn-sm">Logout</button>
             </form>

--- a/templates/plugin.html
+++ b/templates/plugin.html
@@ -22,7 +22,8 @@
     <button class="btn btn-primary"
             hx-post="/{{ $.PluginName }}/actions{{ .Path }}"
             hx-target="#action-result"
-            hx-swap="innerHTML">
+            hx-swap="innerHTML"
+            hx-confirm="Execute '{{ .Description }}'?">
         {{ .Description }}
     </button>
     {{ end }}

--- a/templates/update.html
+++ b/templates/update.html
@@ -18,6 +18,30 @@
         <p class="value">{{ .SecurityCount }}</p>
     </div>
 </div>
+
+{{ if .Pending }}
+<h3>Packages</h3>
+<table class="data-table">
+    <thead>
+        <tr>
+            <th>Package</th>
+            <th>Current</th>
+            <th>New</th>
+            <th>Security</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{ range .Pending }}
+        <tr>
+            <td>{{ .Package }}</td>
+            <td>{{ .CurrentVersion }}</td>
+            <td>{{ .NewVersion }}</td>
+            <td>{{ if .Security }}<span class="badge badge-security" aria-label="Security update" title="Security update">!</span>{{ end }}</td>
+        </tr>
+        {{ end }}
+    </tbody>
+</table>
+{{ end }}
 {{ end }}
 
 {{ if not .LogsErr }}
@@ -27,8 +51,16 @@
         <h3>Last Run</h3>
         <p class="value">{{ .RunStatus.Type }} — {{ .RunStatus.Status }}</p>
         {{ if .RunStatus.StartedAt }}<p class="detail">{{ .RunStatus.StartedAt }}</p>{{ end }}
+        {{ if .RunStatus.Duration }}<p class="detail">Duration: {{ .RunStatus.Duration }}</p>{{ end }}
+        {{ if .RunStatus.Status }}<p class="detail">Packages: {{ .RunStatus.Packages }}</p>{{ end }}
     </div>
 </div>
+{{ if .RunStatus.Log }}
+<details class="log-viewer">
+    <summary>View log output</summary>
+    <pre class="log-pre">{{ .RunStatus.Log }}</pre>
+</details>
+{{ end }}
 {{ end }}
 {{ end }}
 
@@ -42,7 +74,8 @@
             hx-vals='{"type":"full"}'
             hx-target="#update-result"
             hx-swap="innerHTML"
-            hx-indicator="#update-spinner">
+            hx-indicator="#update-spinner"
+            hx-confirm="Run a full system update? This will update all packages.">
         Run Full Update
     </button>
 
@@ -52,7 +85,8 @@
             hx-vals='{"type":"security"}'
             hx-target="#update-result"
             hx-swap="innerHTML"
-            hx-indicator="#update-spinner">
+            hx-indicator="#update-spinner"
+            hx-confirm="Run security-only update? This will install security patches.">
         Run Security Update
     </button>
     {{ end }}

--- a/web.go
+++ b/web.go
@@ -261,10 +261,10 @@ func (h *Handler) fetchPlugins(r *http.Request) ([]PluginInfo, error) {
 	return plugins, nil
 }
 
-// withPlugins adds the Plugins list to a template data map with fallback to
-// stale cached data when the API is unreachable. If both the API and cache
-// (including expired entries) are empty, PluginsUnavailable is set so the
-// template can show a message.
+// withPlugins adds the Plugins list and sidebar NodeInfo to a template data
+// map with fallback to stale cached data when the API is unreachable. If
+// both the API and cache (including expired entries) are empty,
+// PluginsUnavailable is set so the template can show a message.
 func (h *Handler) withPlugins(r *http.Request, data map[string]any) map[string]any {
 	plugins, err := h.fetchPlugins(r)
 	if err != nil {
@@ -276,6 +276,19 @@ func (h *Handler) withPlugins(r *http.Request, data map[string]any) map[string]a
 	data["Plugins"] = plugins
 	if err != nil && len(plugins) == 0 {
 		data["PluginsUnavailable"] = true
+	}
+
+	// Sidebar: inject node info for hostname + uptime display.
+	// Best-effort — skip when the plugin fetch already failed (avoids a
+	// second timeout that would double page-load latency when API is down).
+	if err == nil {
+		if _, ok := data["SidebarNode"]; !ok {
+			var node NodeInfo
+			if nodeErr := h.client.get(r.Context(), "/api/v1/node", &node); nodeErr == nil {
+				data["SidebarNode"] = node
+				data["SidebarConnected"] = true
+			}
+		}
 	}
 	return data
 }

--- a/web_test.go
+++ b/web_test.go
@@ -351,6 +351,47 @@ func TestSidebarUsesStaleCache_WhenAPIDown(t *testing.T) {
 	}
 }
 
+// ---------- Sidebar node info tests ----------
+
+func TestSidebar_ShowsHostnameAndUptime(t *testing.T) {
+	api := mockAPI(t)
+	defer api.Close()
+
+	h := newTestHandler(t, api.URL, "")
+	req := httptest.NewRequest(http.MethodGet, "/update", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, body)
+	}
+	for _, want := range []string{"test-node", "conn-dot", "conn-ok", "up 2d"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("sidebar should contain %q", want)
+		}
+	}
+}
+
+func TestSidebar_NoCrashWhenAPIDown(t *testing.T) {
+	// Point at a closed server — API unreachable.
+	srv := httptest.NewServer(http.NotFoundHandler())
+	srv.Close()
+
+	h := newTestHandler(t, srv.URL, "")
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 even when API is down, got %d", w.Code)
+	}
+	// Sidebar info section should be absent (graceful degradation).
+	if strings.Contains(w.Body.String(), "sidebar-host") {
+		t.Error("sidebar should not show host info when API is unreachable")
+	}
+}
+
 // ---------- Thundering herd prevention tests ----------
 
 func TestFetchPlugins_DoubleCheck(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds TUI↔Web feature parity (PR 1 of 2 for #11):

### Functional
- **Package list table** — individual pending packages with name, current/new version, security badge
- **Expanded Last Run** — duration and package count alongside type/status/timestamp
- **Collapsible log viewer** — raw log output in \<details>\ block
- **Confirmation dialogs** — \hx-confirm\ on Run Full Update, Run Security Update, and generic plugin POST actions

### Cosmetic
- **Sidebar info** — hostname, uptime, and green connection indicator in sidebar footer

### Safety
- Log truncated at 256 KB to prevent OOM on ARM devices
- Node fetch short-circuited when plugin API already failed (avoids double timeout)
- Sidebar degrades gracefully when API unreachable

### Tests
- Package list content, log viewer content, both confirm dialog messages
- Empty-state rendering (no table when empty, no log viewer when empty)
- Sidebar hostname/uptime display and graceful degradation

### Docs
- README, USAGE.md, SPEC.md updated

Addresses #11