### PR TITLE
fix: add response body size limit to apiClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Generic plugin pages fetch all GET endpoints concurrently. A **semaphore**
 (channel of size 10) caps the number of in-flight API calls per request,
 preventing a plugin with many endpoints from overwhelming the core API.
 
+### Response body limit
+
+Every API response is capped at **2 MB** before JSON decoding
+(`maxResponseBytes` in `apiclient.go`). This prevents unbounded memory
+allocation on ARM devices with limited RAM. Oversized responses return a
+descriptive error; the constant is a single-line change if it needs tuning.
+
 ### RoutePrefix validation
 
 Plugin registry entries include a `RoutePrefix` used to build API paths.

--- a/apiclient.go
+++ b/apiclient.go
@@ -20,6 +20,29 @@ type apiClient struct {
 	http    *http.Client
 }
 
+// maxResponseBytes caps the amount of response body data the client will read
+// before decoding JSON.  This prevents unbounded memory allocation when the
+// API returns unexpectedly large payloads (e.g. verbose update logs) — important
+// on ARM devices with limited RAM.
+const maxResponseBytes = 2 << 20 // 2 MB
+
+// decodeJSON reads up to maxResponseBytes+1 from r, returning a clear error
+// when the response exceeds the limit rather than the ambiguous "unexpected
+// EOF" produced by json.NewDecoder over io.LimitReader.
+func decodeJSON(r io.Reader, dst any) error {
+	buf, err := io.ReadAll(io.LimitReader(r, maxResponseBytes+1))
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if len(buf) > maxResponseBytes {
+		return fmt.Errorf("response body exceeds %d byte limit", maxResponseBytes)
+	}
+	if err := json.Unmarshal(buf, dst); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
 func newAPIClient(baseURL, token string) *apiClient {
 	return &apiClient{
 		baseURL: baseURL,
@@ -78,8 +101,8 @@ func (c *apiClient) get(ctx context.Context, path string, dst any) error {
 	}
 
 	if dst != nil {
-		if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
-			return fmt.Errorf("decode response: %w", err)
+		if err := decodeJSON(resp.Body, dst); err != nil {
+			return err
 		}
 	}
 
@@ -116,8 +139,8 @@ func (c *apiClient) post(ctx context.Context, path string, body io.Reader, dst a
 	}
 
 	if dst != nil && resp.StatusCode != http.StatusNoContent {
-		if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
-			return fmt.Errorf("decode response: %w", err)
+		if err := decodeJSON(resp.Body, dst); err != nil {
+			return err
 		}
 	}
 
@@ -153,8 +176,8 @@ func (c *apiClient) put(ctx context.Context, path string, body io.Reader, dst an
 	}
 
 	if dst != nil && resp.StatusCode != http.StatusNoContent {
-		if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
-			return fmt.Errorf("decode response: %w", err)
+		if err := decodeJSON(resp.Body, dst); err != nil {
+			return err
 		}
 	}
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -96,3 +96,10 @@ and tablets.
 - SameSite=Strict prevents cross-site request forgery
 - For production use, configure a strong random token
 - The web UI is intended for LAN access only
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| "response body exceeds … byte limit" | API response larger than 2 MB | Reduce payload at the source or raise `maxResponseBytes` in `apiclient.go` |
+| Empty log section after a large upgrade | Log response exceeded 2 MB wire limit | Logs are still available via the core API directly (`curl /api/v1/plugins/update/logs`) |

--- a/routes_test.go
+++ b/routes_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -537,6 +538,60 @@ func TestAPIClient_GetInvalidJSON(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "decode") {
 		t.Fatalf("error should mention decode: %v", err)
+	}
+}
+
+func TestAPIClient_OversizedResponseRejected(t *testing.T) {
+	// Serve a JSON response larger than maxResponseBytes for every path.
+	// Payload is derived from the constant so the test stays valid if the limit changes.
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"hostname":"`))
+		payloadSize := int(maxResponseBytes) + 1024
+		chunk := bytes.Repeat([]byte("x"), 64*1024)
+		for written := 0; written < payloadSize; written += len(chunk) {
+			remaining := payloadSize - written
+			if remaining < len(chunk) {
+				w.Write(chunk[:remaining])
+				break
+			}
+			w.Write(chunk)
+		}
+		w.Write([]byte(`"}`))
+	}))
+	defer api.Close()
+
+	c := newAPIClient(api.URL, "")
+
+	cases := []struct {
+		name string
+		fn   func() error
+	}{
+		{"get", func() error {
+			var n NodeInfo
+			return c.get(context.Background(), "/huge", &n)
+		}},
+		{"post", func() error {
+			var n NodeInfo
+			return c.post(context.Background(), "/huge", nil, &n)
+		}},
+		{"put", func() error {
+			var n NodeInfo
+			return c.put(context.Background(), "/huge", nil, &n)
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.fn()
+			if err == nil {
+				t.Fatal("expected error for oversized response")
+			}
+			if !strings.Contains(err.Error(), "exceeds") {
+				t.Fatalf("error should mention size limit exceeded: %v", err)
+			}
+		})
 	}
 }
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -171,6 +171,12 @@ locking).
 
 ## Error Handling
 
+- **Response body size limit**: the API client enforces a maximum response
+  size (`maxResponseBytes` in `apiclient.go`, default ~2 MB) before JSON
+  decoding. Responses that exceed this limit produce a clear
+  `response body exceeds <limit> byte limit` error instead of allocating
+  unbounded memory. The 256 KB log truncation in `handleUpdate` operates
+  at the template layer and is complementary.
 - API errors displayed as alert banners on the relevant page
 - Template render errors logged and return 500
 - Default-show behavior: pages render with error messages rather than blank


### PR DESCRIPTION
Closes #21

## What

Adds a decodeJSON helper that reads up to 2 MB from the API response body before JSON unmarshalling. This prevents unbounded memory allocation on ARM devices with limited RAM.

## Changes

- **apiclient.go**: New decodeJSON() function wraps io.ReadAll(io.LimitReader(r, maxResponseBytes+1)) with a clear "response body exceeds N byte limit" error instead of the ambiguous "unexpected EOF" from io.LimitReader + json.Decoder. Applied to all 3 HTTP methods (get/post/put) via the shared helper.
- **routes_test.go**: Table-driven TestAPIClient_OversizedResponseRejected covering get, post, and put with a 3 MB response.

## Design notes

- 2 MB limit is intentionally conservative for 512 MB ARM devices. The constant is a single-line change if it needs bumping.
- Complements the existing 256 KB log truncation in handleUpdate — they protect different layers (wire-level decode cap vs template-level display cap).
- If the logs endpoint response exceeds 2 MB, the handler degrades gracefully (empty log section) rather than OOM-killing the process.