### PR TITLE
feat: handle 403 policy-denied errors gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ headless Debian-based nodes (Raspbian Bookworm ARM, Debian Bullseye slim).
 - Cookie-based authentication using the same Bearer token as the API
 - Responsive dark theme — works on phones, tablets, and desktops
 - Server-rendered with htmx — no JavaScript build step required
+- **Write-policy awareness** — network write operations denied by interface
+  policy show a warning-level toast with actionable guidance instead of a
+  generic error
 - **Skeleton loading** — pages render instant skeleton placeholders, then
   htmx lazy-loads data from fragment endpoints for perceived performance
 - Dynamic plugin sidebar — auto-discovers plugins from the core API registry
@@ -68,6 +71,24 @@ incoming form data at **1 MB** (`maxFormBytes` in `routes_network.go`). This
 prevents oversized submissions from consuming memory on resource-constrained
 ARM devices. Requests exceeding the limit receive an inline error with a toast
 notification.
+
+### Network write error handling
+
+`writeNetworkError` in `routes_network.go` renders inline alerts with
+expandable details and an out-of-band toast notification. It distinguishes
+**403 Forbidden** responses from other errors:
+
+- **403** — the toast level is downgraded from `error` to `warning`, and the
+  title is overridden to "Interface protected by policy" so the user sees
+  actionable guidance instead of a scary red error.
+- **All other errors** — rendered as `error`-level alerts with the original
+  operation title (e.g. "Failed to set static IP for eth0").
+
+The `toastLevel` variable is validated against a whitelist (`"error"` /
+`"warning"`) before being interpolated into the HTML class attribute. This
+prevents CSS-class injection if future code paths introduce new levels
+without sanitization. The `toastOOB` helper applies a second whitelist for
+defense in depth.
 
 ### RoutePrefix validation
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -153,6 +153,7 @@ and tablets.
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
+| "Interface protected by policy" warning | The core network plugin's `interface_policy` denies writes to this interface | Check `interface_policy` in the network plugin config — add the interface to the allow list or remove it from the deny list |
 | "response body exceeds … byte limit" | API response larger than 2 MB | Reduce payload at the source or raise `maxResponseBytes` in `apiclient.go` |
 | Empty log section after a large upgrade | Log response exceeded 2 MB wire limit | Logs are still available via the core API directly (`curl /api/v1/plugins/update/logs`) |
 | "Failed to check job status" in progress | Core API unreachable while polling job | Verify the core service is running; the job may still complete in the background |

--- a/routes_network.go
+++ b/routes_network.go
@@ -43,14 +43,24 @@ func parseFormLimited(w http.ResponseWriter, r *http.Request) error {
 func (h *Handler) writeNetworkError(w http.ResponseWriter, title string, err error) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	safeErr := html.EscapeString(err.Error())
-	if apiErr, ok := err.(*APIError); ok {
+	toastLevel := "error"
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
 		safeErr = html.EscapeString(apiErr.Message)
+		if apiErr.StatusCode == http.StatusForbidden {
+			toastLevel = "warning"
+			title = "Interface protected by policy"
+		}
 	}
-	_, _ = w.Write([]byte(`<div class="alert alert-error"><strong>` + //nolint:errcheck // HTTP write
+	// Whitelist toastLevel to prevent injection if logic above is extended.
+	if toastLevel != "error" && toastLevel != "warning" {
+		toastLevel = "error"
+	}
+	_, _ = w.Write([]byte(`<div class="alert alert-` + toastLevel + `"><strong>` + //nolint:errcheck // HTTP write
 		html.EscapeString(title) + `</strong>` +
 		`<details class="error-details"><summary>Show details</summary>` +
 		`<pre>` + safeErr + `</pre></details></div>` +
-		toastOOB("error", title)))
+		toastOOB(toastLevel, title)))
 }
 
 // writeFormError writes an inline alert for parseFormLimited failures.

--- a/routes_network_test.go
+++ b/routes_network_test.go
@@ -860,7 +860,7 @@ func TestNetworkHandlers_OversizedBody(t *testing.T) {
 	}
 }
 
-// ---------- writeNetworkError generic error branch ----------
+// ---------- writeNetworkError ----------
 
 func TestWriteNetworkError_GenericError(t *testing.T) {
 	// Point the handler at an unreachable API so the HTTP client returns a
@@ -882,6 +882,171 @@ func TestWriteNetworkError_GenericError(t *testing.T) {
 	// Ensure the error detail block is present (the <pre> with error text).
 	if !strings.Contains(body, "<pre>") {
 		t.Error("expected error details in response")
+	}
+	// Generic errors must produce error-level (not warning) styling.
+	if !strings.Contains(body, `alert-error`) {
+		t.Error("expected alert-error class for generic error")
+	}
+}
+
+func TestWriteNetworkError_403PolicyWarning(t *testing.T) {
+	// Backend returns 403 with a policy error message.
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":403,"message":"interface 'lo' is not allowed for write operations"}}`))
+	}))
+	defer api.Close()
+
+	h := newTestHandler(t, api.URL, "")
+	form := "name=lo&address=127.0.0.1%2F8&netmask=255.0.0.0"
+	req := httptest.NewRequest(http.MethodPost, "/network/set-static-ip", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	// Must use warning-level styling, not error.
+	if !strings.Contains(body, `alert-warning`) {
+		t.Errorf("expected alert-warning class for 403, got: %s", body)
+	}
+	if strings.Contains(body, `alert-error`) {
+		t.Error("403 should not produce alert-error class")
+	}
+	// Title must be overridden to the policy message.
+	if !strings.Contains(body, "Interface protected by policy") {
+		t.Errorf("expected policy title, got: %s", body)
+	}
+	// API message should appear in the detail block.
+	if !strings.Contains(body, "not allowed for write operations") {
+		t.Errorf("expected API message in details, got: %s", body)
+	}
+	// OOB toast must be warning-level.
+	if !strings.Contains(body, `hx-swap-oob`) {
+		t.Error("expected OOB toast in 403 response")
+	}
+}
+
+func TestWriteNetworkError_400APIErrorKeepsErrorLevel(t *testing.T) {
+	// Backend returns 400 — should remain error-level with original title.
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":400,"message":"bad payload"}}`))
+	}))
+	defer api.Close()
+
+	h := newTestHandler(t, api.URL, "")
+	form := "name=eth0&address=10.0.0.1%2F24&netmask=255.255.255.0"
+	req := httptest.NewRequest(http.MethodPost, "/network/set-static-ip", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	// Must remain error-level.
+	if !strings.Contains(body, `alert-error`) {
+		t.Errorf("expected alert-error class for 400, got: %s", body)
+	}
+	if strings.Contains(body, `alert-warning`) {
+		t.Error("400 should not produce alert-warning class")
+	}
+	// Original title should be preserved (not overridden to policy message).
+	if !strings.Contains(body, "Failed to set static IP") {
+		t.Errorf("expected original title for 400, got: %s", body)
+	}
+	if strings.Contains(body, "Interface protected by policy") {
+		t.Error("400 should not show policy title")
+	}
+}
+
+func TestWriteNetworkError_403XSSInMessage(t *testing.T) {
+	// Backend returns 403 with an XSS payload in the error message.
+	// Verifies HTML escaping in the warning (403) code path specifically.
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":403,"message":"<script>alert('xss')</script>"}}`))
+	}))
+	defer api.Close()
+
+	h := newTestHandler(t, api.URL, "")
+	form := "name=eth0&address=10.0.0.1%2F24&netmask=255.255.255.0"
+	req := httptest.NewRequest(http.MethodPost, "/network/set-static-ip", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if strings.Contains(body, "<script>") {
+		t.Error("403 response must not contain raw <script> tag (XSS)")
+	}
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Error("403 response must contain HTML-escaped script tag")
+	}
+	if !strings.Contains(body, `alert-warning`) {
+		t.Error("403 with XSS payload must still use warning level")
+	}
+}
+
+func TestNetworkHandlers_403PolicyWarning(t *testing.T) {
+	// All network write handlers funnel through writeNetworkError.
+	// Verify each handler renders 403 as a warning toast with policy title.
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":403,"message":"interface policy denies this operation"}}`))
+	}))
+	defer api.Close()
+
+	h := newTestHandler(t, api.URL, "")
+	handlers := []struct {
+		name, path, form string
+	}{
+		{"SetStaticIP", "/network/set-static-ip", "name=eth0&address=10.0.0.1%2F24&netmask=255.255.255.0"},
+		{"SetDNS", "/network/set-dns", "nameservers=8.8.8.8"},
+		{"DeleteStaticIP", "/network/delete-static-ip", "name=eth0"},
+		{"RollbackInterface", "/network/rollback-interface", "name=eth0"},
+		{"RollbackDNS", "/network/rollback-dns", ""},
+	}
+	for _, tc := range handlers {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.form))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			body := w.Body.String()
+			if !strings.Contains(body, `alert-warning`) {
+				t.Errorf("expected alert-warning class for 403, got: %s", body)
+			}
+			if strings.Contains(body, `alert-error`) {
+				t.Error("403 must not produce alert-error class")
+			}
+			if !strings.Contains(body, "Interface protected by policy") {
+				t.Errorf("expected policy title, got: %s", body)
+			}
+			if !strings.Contains(body, `hx-swap-oob`) {
+				t.Error("expected OOB toast in 403 response")
+			}
+		})
+	}
+}
+
+func TestWriteNetworkError_WarningToastUsesStatusRole(t *testing.T) {
+	// Warning-level toasts use role="status" (non-critical), not role="alert".
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":403,"message":"denied"}}`))
+	}))
+	defer api.Close()
+
+	h := newTestHandler(t, api.URL, "")
+	form := "name=eth0&address=10.0.0.1%2F24&netmask=255.255.255.0"
+	req := httptest.NewRequest(http.MethodPost, "/network/set-static-ip", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, `role="status"`) {
+		t.Error("warning-level toast must use role=status for non-critical notification")
 	}
 }
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -231,3 +231,28 @@ locking).
 - API errors displayed as alert banners on the relevant page
 - Template render errors logged and return 500
 - Default-show behavior: pages render with error messages rather than blank
+
+### Network Write 403 Policy Denials
+
+When a network write operation (set static IP, set DNS, delete static IP,
+rollback interface, rollback DNS) receives a **403 Forbidden** response from
+the core API, the web UI treats it differently from other errors:
+
+1. **Toast level** — downgraded from `error` to `warning` (amber styling
+   instead of red).
+2. **Title override** — the operation-specific title (e.g. "Failed to set
+   static IP for eth0") is replaced with **"Interface protected by policy"**
+   to give the user a clear, actionable message.
+3. **Detail block** — the original API error message (e.g. "interface 'lo'
+   is not allowed for write operations") is preserved in the expandable
+   `<details>` section for debugging.
+4. **ARIA role** — warning toasts use `role="status"` instead of
+   `role="alert"` since the condition is informational, not critical.
+
+This behavior is implemented in `writeNetworkError` (`routes_network.go`).
+All five network write handlers delegate to this function on API failure, so
+the 403 logic applies uniformly.
+
+The `toastLevel` value is validated against a whitelist before interpolation
+into HTML class attributes to prevent injection if future code paths introduce
+additional levels.


### PR DESCRIPTION
## Summary

Handle 403 policy-denied errors from the network plugin gracefully in the web UI.

When a network write operation is denied by interface policy, the web UI now shows a **warning-level toast** with the title "Interface protected by policy" instead of a generic red error. This gives the user clear, actionable guidance.

## Changes

- **routes_network.go** -- `writeNetworkError` detects `*APIError` with 403 status via `errors.As`, downgrades toast level from error to warning, overrides title to policy message. `toastLevel` whitelist prevents CSS-class injection.
- **routes_network_test.go** -- 6 new tests: 403 warning toast, 400 keeps error level, XSS in 403 path, all 5 handlers produce warning for 403, ARIA role=status for warnings, generic error class assertion.
- **README.md** -- Added write-policy awareness feature bullet and network write error handling architecture section.
- **specs/SPEC.md** -- Added Network Write 403 Policy Denials section with full behavioral spec.
- **docs/USAGE.md** -- Added troubleshooting row for "Interface protected by policy" warnings.

## Testing

All 6 new tests pass. Existing tests unaffected. `golangci-lint` clean.

## Fleet Review

10-agent fleet review completed (5 TUI + 5 Web). One finding fixed: replaced `err.(*APIError)` type assertion with `errors.As(err, &apiErr)` for robustness against wrapped errors.