### PR TITLE
security: sanitize template-rendered data and add sanitizeBody()

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -43,7 +43,7 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := map[string]any{
-		"Error": r.URL.Query().Get("error"),
+		"Error": sanitizeForDisplay(r.URL.Query().Get("error")),
 	}
 	h.render(w, "login.html", data)
 }

--- a/routes.go
+++ b/routes.go
@@ -44,10 +44,33 @@ func sanitizeForDisplay(s string) string {
 	return b.String()
 }
 
+// sanitizeBody strips control and BiDi characters but preserves newlines and
+// tabs so that multiline content (logs, JSON) can be rendered inside <pre>
+// blocks. Mirrors the TUI implementation for parity.
+func sanitizeBody(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r == '\n' || r == '\t' || (!unicode.IsControl(r) && !isBiDiControl(r)) {
+			_, _ = b.WriteRune(r) //nolint:errcheck // strings.Builder.WriteRune never fails
+		}
+	}
+	return b.String()
+}
+
 // safeHTML strips control/BiDi characters and then HTML-escapes for safe
 // interpolation into HTML output.
 func safeHTML(s string) string {
 	return html.EscapeString(sanitizeForDisplay(s))
+}
+
+// sanitizeErr returns the sanitised string representation of an error, or ""
+// if the error is nil. Suitable for passing to templates as defense-in-depth.
+func sanitizeErr(err error) string {
+	if err == nil {
+		return ""
+	}
+	return sanitizeForDisplay(err.Error())
 }
 
 // ---------- Toast notifications ----------
@@ -443,7 +466,7 @@ func (h *Handler) handleDashboardFragment(w http.ResponseWriter, r *http.Request
 
 	data := map[string]any{
 		"Node":    node,
-		"NodeErr": nodeErr,
+		"NodeErr": sanitizeErr(nodeErr),
 	}
 	h.renderFragment(w, "frag-dashboard.html", data)
 }
@@ -509,6 +532,9 @@ func (h *Handler) handleUpdateFragment(w http.ResponseWriter, r *http.Request) {
 		runStatus.Log = runStatus.Log[:cut] + "\n…(truncated)"
 	}
 
+	// Sanitize log content: strip control/BiDi chars but keep newlines/tabs.
+	runStatus.Log = sanitizeBody(runStatus.Log)
+
 	// Compute counts from the pending list.
 	securityCount := 0
 	for _, p := range pending {
@@ -522,10 +548,10 @@ func (h *Handler) handleUpdateFragment(w http.ResponseWriter, r *http.Request) {
 		"PendingCount":  len(pending),
 		"SecurityCount": securityCount,
 		"RunStatus":     runStatus,
-		"StatusErr":     statusErr,
-		"LogsErr":       logsErr,
+		"StatusErr":     sanitizeErr(statusErr),
+		"LogsErr":       sanitizeErr(logsErr),
 		"Config":        config,
-		"ConfigErr":     configErr,
+		"ConfigErr":     sanitizeErr(configErr),
 	}
 	h.renderFragment(w, "frag-update.html", data)
 }
@@ -693,7 +719,7 @@ func (h *Handler) handleProgress(w http.ResponseWriter, r *http.Request) {
 		"Status":     run.Status,
 		"StartedAt":  run.StartedAt,
 		"Duration":   run.Duration,
-		"Error":      run.Error,
+		"Error":      sanitizeForDisplay(run.Error),
 		"ReturnURL":  returnURL,
 		"RetryCount": strconv.Itoa(retryCount),
 	}
@@ -749,7 +775,7 @@ func (h *Handler) handleHistoryFragment(w http.ResponseWriter, r *http.Request) 
 	}
 	if err != nil {
 		slog.Error("web: failed to fetch job runs", "job", jobID, "error", err)
-		data["Error"] = err.Error()
+		data["Error"] = sanitizeForDisplay(err.Error())
 	} else {
 		data["Runs"] = runs
 		data["HasPrev"] = offset > 0
@@ -948,11 +974,11 @@ func (h *Handler) handleNetworkFragment(w http.ResponseWriter, r *http.Request) 
 
 	data := map[string]any{
 		"Ifaces":    ifaces,
-		"IfaceErr":  ifaceErr,
+		"IfaceErr":  sanitizeErr(ifaceErr),
 		"Status":    status,
-		"StatusErr": statusErr,
+		"StatusErr": sanitizeErr(statusErr),
 		"DNS":       dns,
-		"DNSErr":    dnsErr,
+		"DNSErr":    sanitizeErr(dnsErr),
 	}
 	h.renderFragment(w, "frag-network.html", data)
 }

--- a/routes_test.go
+++ b/routes_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"html/template"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -4771,5 +4773,124 @@ func TestIsBiDiControl(t *testing.T) {
 		if isBiDiControl(r) {
 			t.Errorf("isBiDiControl(%U) = true, want false", r)
 		}
+	}
+}
+
+func TestSanitizeBody(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"plain text", "hello world", "hello world"},
+		{"preserves newlines", "line1\nline2\nline3", "line1\nline2\nline3"},
+		{"preserves tabs", "col1\tcol2\tcol3", "col1\tcol2\tcol3"},
+		{"preserves mixed whitespace", "heading\n\tindented\n\tmore", "heading\n\tindented\n\tmore"},
+		{"strips null byte", "abc\x00def", "abcdef"},
+		{"strips bell", "abc\x07def", "abcdef"},
+		{"strips ESC (ANSI prefix)", "\x1b[31mred\x1b[0m", "[31mred[0m"},
+		{"strips C1 controls", "abc\u0085\u009Bdef", "abcdef"},
+		{"strips DEL", "abc\x7Fdef", "abcdef"},
+		{"strips BiDi LRO", "abc\u202Ddef", "abcdef"},
+		{"strips BiDi RLO", "abc\u202Edef", "abcdef"},
+		{"strips BiDi LRI", "abc\u2066def", "abcdef"},
+		{"strips BiDi PDI", "abc\u2069def", "abcdef"},
+		{"strips BiDi LRE", "abc\u202Adef", "abcdef"},
+		{"strips BiDi RLE", "abc\u202Bdef", "abcdef"},
+		{"strips BiDi PDF", "abc\u202Cdef", "abcdef"},
+		{"strips BiDi RLI", "abc\u2067def", "abcdef"},
+		{"strips BiDi FSI", "abc\u2068def", "abcdef"},
+		{"strips LRM", "abc\u200Edef", "abcdef"},
+		{"strips RLM", "abc\u200Fdef", "abcdef"},
+		{"strips ALM", "abc\u061Cdef", "abcdef"},
+		{"mixed BiDi and newlines", "line1\u202E\nline2\u202D\n", "line1\nline2\n"},
+		{"only newlines", "\n\n\n", "\n\n\n"},
+		{"only tabs", "\t\t", "\t\t"},
+		{"preserves ZWJ", "abc\u200Ddef", "abc\u200Ddef"},
+		{"preserves emoji", "Hello 🌍!", "Hello 🌍!"},
+		{"log-like content", "2024-01-01 Starting update...\n\tPackage: vim\n\tStatus: ok\n", "2024-01-01 Starting update...\n\tPackage: vim\n\tStatus: ok\n"},
+		{"strips CR keeps LF", "line1\r\nline2", "line1\nline2"},
+		{"empty string", "", ""},
+		{"only controls", "\x00\x01\x02\x03", ""},
+		{"invalid UTF-8", "\xed\xa0\x80", "\ufffd\ufffd\ufffd"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeBody(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeBody(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil error", nil, ""},
+		{"plain error", errors.New("connection refused"), "connection refused"},
+		{"error with control chars", errors.New("fail\x00ed\x1b[31m"), "failed[31m"},
+		{"error with BiDi", errors.New("err\u202Eor"), "error"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeErr(tc.err)
+			if got != tc.want {
+				t.Errorf("sanitizeErr(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTemplateFuncMapRegistration(t *testing.T) {
+	tmpl := template.Must(template.New("test").Funcs(template.FuncMap{
+		"sanitize":     sanitizeForDisplay,
+		"sanitizeBody": sanitizeBody,
+	}).Parse(`{{ .Error | sanitize }}|{{ .Log | sanitizeBody }}`))
+
+	data := map[string]string{
+		"Error": "fail\u202Eed",
+		"Log":   "line1\n\x1b[31mred\x1b[0m\nline2",
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("template execute: %v", err)
+	}
+
+	got := buf.String()
+	want := "failed|line1\n[31mred[0m\nline2"
+	if got != want {
+		t.Errorf("template output = %q, want %q", got, want)
+	}
+}
+
+func TestTemplateSanitizeConditional(t *testing.T) {
+	// Verify that {{ if (.Field | sanitize) }} works correctly:
+	// empty string after sanitization is falsy in Go templates.
+	tmpl := template.Must(template.New("cond").Funcs(template.FuncMap{
+		"sanitize": sanitizeForDisplay,
+	}).Parse(`{{ if (.Error | sanitize) }}HAS_ERROR{{ else }}NO_ERROR{{ end }}`))
+
+	tests := []struct {
+		name, input, want string
+	}{
+		{"real error", "connection refused", "HAS_ERROR"},
+		{"empty string", "", "NO_ERROR"},
+		{"only control chars", "\x00\x1b\u202E", "NO_ERROR"},
+		{"mixed keeps text", "err\u202Eor", "HAS_ERROR"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			data := map[string]string{"Error": tc.input}
+			if err := tmpl.Execute(&buf, data); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if got := buf.String(); got != tc.want {
+				t.Errorf("input %q → %q, want %q", tc.input, got, tc.want)
+			}
+		})
 	}
 }

--- a/templates/frag-dashboard.html
+++ b/templates/frag-dashboard.html
@@ -1,5 +1,5 @@
 {{ if .NodeErr }}
-<div class="alert alert-error">Failed to load system info: {{ .NodeErr }} <button class="btn btn-sm" onclick="htmx.trigger(document.getElementById('page-data'),'retry')">Retry</button></div>
+<div class="alert alert-error">Failed to load system info: {{ .NodeErr | sanitize }} <button class="btn btn-sm" onclick="htmx.trigger(document.getElementById('page-data'),'retry')">Retry</button></div>
 {{ else }}
 <div class="card-grid">
     <div class="card">

--- a/templates/frag-history.html
+++ b/templates/frag-history.html
@@ -1,5 +1,5 @@
 {{ if .Error }}
-<div class="alert alert-error">Failed to load job history: {{ .Error }} <button class="btn btn-sm" onclick="htmx.trigger(document.getElementById('page-data'),'retry')">Retry</button></div>
+<div class="alert alert-error">Failed to load job history: {{ .Error | sanitize }} <button class="btn btn-sm" onclick="htmx.trigger(document.getElementById('page-data'),'retry')">Retry</button></div>
 {{ else if and (not .Runs) (not .HasPrev) }}
 <p>No runs recorded for this job.</p>
 {{ else }}
@@ -19,7 +19,7 @@
             <td>{{ if eq .Status "completed" }}<span title="Completed">✓</span>{{ else if eq .Status "failed" }}<span title="Failed">✗</span>{{ else }}{{ .Status }}{{ end }}</td>
             <td>{{ .StartedAt }}</td>
             <td>{{ .Duration }}</td>
-            <td>{{ .Error }}</td>
+            <td>{{ .Error | sanitize }}</td>
         </tr>
         {{ end }}
     </tbody>

--- a/templates/frag-network.html
+++ b/templates/frag-network.html
@@ -1,5 +1,5 @@
 {{ if .StatusErr }}
-<div class="alert alert-error">Failed to load network status: {{ .StatusErr }} <button class="btn btn-sm" onclick="htmx.trigger(document.getElementById('page-data'),'retry')">Retry</button></div>
+<div class="alert alert-error">Failed to load network status: {{ .StatusErr | sanitize }} <button class="btn btn-sm" onclick="htmx.trigger(document.getElementById('page-data'),'retry')">Retry</button></div>
 {{ else }}
 <div class="card-grid">
     <div class="card">
@@ -28,7 +28,7 @@
 <div id="network-result"></div>
 
 {{ if .IfaceErr }}
-<div class="alert alert-error">Failed to load interfaces: {{ .IfaceErr }}</div>
+<div class="alert alert-error">Failed to load interfaces: {{ .IfaceErr | sanitize }}</div>
 {{ else if .Ifaces }}
 <table class="data-table">
     <thead>

--- a/templates/frag-plugin.html
+++ b/templates/frag-plugin.html
@@ -4,9 +4,9 @@
 <div class="card">
     <h3>{{ .Description }}</h3>
     {{ if .Error }}
-    <div class="alert alert-error">{{ .Error }}</div>
+    <div class="alert alert-error">{{ .Error | sanitize }}</div>
     {{ else }}
-    <pre>{{ .Data }}</pre>
+    <pre>{{ .Data | sanitizeBody }}</pre>
     {{ end }}
 </div>
 {{ end }}

--- a/templates/frag-update.html
+++ b/templates/frag-update.html
@@ -1,5 +1,5 @@
 {{ if .StatusErr }}
-<div class="alert alert-error">Failed to load pending updates: {{ .StatusErr }} <button class="btn btn-sm" onclick="htmx.trigger(document.getElementById('page-data'),'retry')">Retry</button></div>
+<div class="alert alert-error">Failed to load pending updates: {{ .StatusErr | sanitize }} <button class="btn btn-sm" onclick="htmx.trigger(document.getElementById('page-data'),'retry')">Retry</button></div>
 {{ else }}
 <div class="card-grid">
     <div class="card">
@@ -51,7 +51,7 @@
 {{ if .RunStatus.Log }}
 <details class="log-viewer">
     <summary>View log output</summary>
-    <pre class="log-pre">{{ .RunStatus.Log }}</pre>
+    <pre class="log-pre">{{ .RunStatus.Log | sanitizeBody }}</pre>
 </details>
 {{ end }}
 {{ else }}

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -14,13 +14,13 @@
 </div>
 {{ else if eq .Status "failed" }}
 <div class="alert alert-error">
-    {{ .JobID }} failed{{ if .Duration }} after {{ .Duration }}{{ end }}{{ if .Error }}: {{ .Error }}{{ end }}.
+    {{ .JobID }} failed{{ if .Duration }} after {{ .Duration }}{{ end }}{{ if .Error }}: {{ .Error | sanitize }}{{ end }}.
 </div>
 {{ else if eq .Status "error" }}
 <div class="alert alert-error"
      hx-get="/progress?job={{ urlquery .JobID }}&amp;return={{ urlquery .ReturnURL }}&amp;retry={{ .RetryCount }}"
      hx-trigger="every 5s" hx-swap="outerHTML">
-    Failed to check job status{{ if .Error }}: {{ .Error }}{{ end }} (retrying…)
+    Failed to check job status{{ if .Error }}: {{ .Error | sanitize }}{{ end }} (retrying…)
 </div>
 {{ else }}
 <div class="alert alert-error">No run data available for {{ .JobID }}.</div>

--- a/web.go
+++ b/web.go
@@ -154,6 +154,8 @@ func NewHandler(apiURL, authToken string) http.Handler {
 	funcMap := template.FuncMap{
 		"formatUptime": formatUptime,
 		"title":        titleCase,
+		"sanitize":     sanitizeForDisplay,
+		"sanitizeBody": sanitizeBody,
 		"derefBool": func(b *bool) bool {
 			if b == nil {
 				return false


### PR DESCRIPTION
## Summary

Closes #47 — sanitize template-rendered data and add `sanitizeBody()` for multiline fields.

## Changes

### New functions (routes.go)
- **`sanitizeBody()`** — strips control + BiDi chars but preserves `\n`/`\t` for `<pre>` blocks. Mirrors TUI implementation for parity.
- **`sanitizeErr()`** — nil-safe helper returns sanitized error string or `""` for nil.

### Template FuncMap (web.go)
- Registered `sanitize` (→ `sanitizeForDisplay`) and `sanitizeBody` as template functions.

### Template pipes (6 files, 12 expressions)
- `frag-update.html`: `.StatusErr | sanitize`, `.RunStatus.Log | sanitizeBody`
- `frag-history.html`: `.Error | sanitize` (2 sites)
- `frag-plugin.html`: `.Error | sanitize`, `.Data | sanitizeBody`
- `frag-dashboard.html`: `.NodeErr | sanitize`
- `frag-network.html`: `.StatusErr | sanitize`, `.IfaceErr | sanitize`
- `progress.html`: `.Error | sanitize` (2 sites)

### Handler pre-sanitization (defense-in-depth)
- 7 route handlers now pre-sanitize error data via `sanitizeErr()`
- auth.go login error from URL query param sanitized
- RunStatus.Log pre-sanitized with `sanitizeBody()`

### Tests (4 new functions, 38+ cases)
- `TestSanitizeBody` — 30 cases including BiDi parity with TUI, newline/tab preservation, ANSI stripping, CR handling, invalid UTF-8
- `TestSanitizeErr` — 4 cases (nil, plain, control chars, BiDi)
- `TestTemplateFuncMapRegistration` — verifies pipeline execution
- `TestTemplateSanitizeConditional` — 4 cases verifying empty-after-sanitize is falsy

## Fleet Review (5 agents)
- Security (Opus 4.6): ✅ Clean
- Correctness (GPT-5.1-Codex): ✅ Clean (all-control-error edge case dismissed — impossible from Go stdlib on localhost)
- Parity (GPT-5.3-Codex): ✅ Fixed (added missing BiDi test cases)
- Tests (Gemini 3 Pro): ✅ Fixed (added edge cases + conditional template test)
- Architecture (Sonnet 4.5): ✅ Clean (defense-in-depth pattern intentional)

## Follow-up
API data fields (Node.Hostname, interface names, DNS servers) are not yet sanitized in templates — tracked separately as these come from local system, not user input.